### PR TITLE
Don't log NebulaAddLightHouseStaticRoute

### DIFF
--- a/nebula_darwin.go
+++ b/nebula_darwin.go
@@ -95,12 +95,5 @@ func NebulaAddLightHouseStaticRoute(e *Endpoint) error {
 			zap.Error(err))
 	}
 
-	if err := exec.Command("/sbin/route", "-n", "add", "-net", e.RemoteIP, defaultGw).Run(); err != nil {
-		Cfg.Logger.Error("Can't create a static route for gRPC server",
-			zap.String("RemoteIP", e.RemoteIP),
-			zap.Error(err))
-		return err
-	}
-
-	return nil
+	return exec.Command("/sbin/route", "-n", "add", "-net", e.RemoteIP, defaultGw).Run()
 }

--- a/nebula_linux.go
+++ b/nebula_linux.go
@@ -92,12 +92,5 @@ func NebulaAddLightHouseStaticRoute(e *Endpoint) error {
 			zap.Error(err))
 	}
 
-	if err := netlink.RouteAdd(&nr); err != nil {
-		Cfg.Logger.Error("Can't create a static route for gRPC server",
-			zap.String("RemoteIP", e.RemoteIP),
-			zap.Error(err))
-		return err
-	}
-
-	return nil
+	return netlink.RouteAdd(&nr)
 }


### PR DESCRIPTION
Error logging is alreade in caller and it's
good practice for library/hellpers to return
error insteaed of logging.