### PR TITLE
fix: ignore a harmless error to avoid a confusing log message

### DIFF
--- a/cmd/nerf/main.go
+++ b/cmd/nerf/main.go
@@ -243,9 +243,7 @@ func main() {
 	nerf.Cfg.Logger = logger
 
 	defer func() {
-		if err := nerf.Cfg.Logger.Sync(); err != nil {
-			panic("failed sync Logger")
-		}
+		_ = nerf.Cfg.Logger.Sync()
 	}()
 
 	if *server {


### PR DESCRIPTION
error message borrowed from https://github.com/influxdata/influxdb/pull/20448