### PR TITLE
GUI: Remove systray title and set tooltip

### DIFF
--- a/cmd/nerf/main.go
+++ b/cmd/nerf/main.go
@@ -18,7 +18,7 @@ func main() {
 
 func onReady() {
 	systray.SetIcon(icon.Data)
-	systray.SetTitle("Hostinger Network")
+	systray.SetTooltip("Hostinger Network")
 
 	mConnect := systray.AddMenuItem("Connect", "Connect to Hostinger Network")
 	mDisconnect := systray.AddMenuItem("Disconnect", "Disconnect from Hostinger Network")


### PR DESCRIPTION
Systray title works only on MAC and takes a lot of space:
![Screenshot at May 06 15-59-23](https://user-images.githubusercontent.com/26375708/117302765-aad60180-ae84-11eb-98fe-02366c1b3639.png)

This title does not appear on linux (xfce4) or windows.

Let's move this description to tooltip. Result:
![Screenshot at May 06 16-00-14](https://user-images.githubusercontent.com/26375708/117303053-f5577e00-ae84-11eb-8578-84a3b18c0780.png)
