### PR TITLE
GUI: Show new icons in systray

### DIFF
--- a/cmd/nerf/main.go
+++ b/cmd/nerf/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/getlantern/systray"
-	"github.com/getlantern/systray/example/icon"
 	"github.com/ton31337/nerf"
+	"github.com/ton31337/nerf/cmd/nerf/icons"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -17,7 +17,7 @@ func main() {
 }
 
 func onReady() {
-	systray.SetIcon(icon.Data)
+	systray.SetIcon(icons.Disconnected)
 	systray.SetTooltip("Hostinger Network")
 
 	mConnect := systray.AddMenuItem("Connect", "Connect to Hostinger Network")
@@ -84,6 +84,7 @@ func connect() {
 		nerf.Cfg.Logger.Fatal("can't connect to gRPC UNIX socket", zap.Error(err))
 	}
 
+	systray.SetIcon(icons.Connected)
 	nerf.Cfg.Connected = true
 }
 
@@ -105,5 +106,6 @@ func disconnect() {
 		nerf.Cfg.Logger.Fatal("can't connect to gRPC UNIX socket", zap.Error(err))
 	}
 
+	systray.SetIcon(icons.Disconnected)
 	nerf.Cfg.Connected = false
 }


### PR DESCRIPTION
Use icons from `icons` package (https://github.com/ton31337/nerf/pull/44)

On mac:
![image](https://user-images.githubusercontent.com/26375708/117448440-6f503b80-af47-11eb-8579-72ce2db30c60.png)
![image](https://user-images.githubusercontent.com/26375708/117448465-76774980-af47-11eb-9822-631637e3949c.png)

On linux (xfce4):
![image](https://user-images.githubusercontent.com/26375708/117448514-87c05600-af47-11eb-8939-6e64db6fd84f.png)
![image](https://user-images.githubusercontent.com/26375708/117448529-8d1da080-af47-11eb-88f0-959e5854612c.png)
