### PR TITLE
Gracefuly handle errors from Nerf server

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -96,7 +96,7 @@ func openBrowser(url string) error {
 		// Running Firefox as root in a regular user's session is not supported.
 		err = exec.Command("xdg-open", url).Start()
 	default:
-		err = fmt.Errorf("unsupported platform")
+		err = ErrUnsupportedPlatform
 	}
 
 	return err
@@ -106,9 +106,11 @@ func openBrowser(url string) error {
 func Auth() {
 	router := http.NewServeMux()
 	server = &http.Server{
-		Addr:     Cfg.ListenAddr,
-		Handler:  router,
-		ErrorLog: nil,
+		Addr:         Cfg.ListenAddr,
+		Handler:      router,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		ErrorLog:     nil,
 	}
 
 	router.HandleFunc("/", handleAuthMain)

--- a/nebula_common.go
+++ b/nebula_common.go
@@ -3,7 +3,6 @@ package nerf
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -240,7 +239,7 @@ func NebulaDownload() (err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed download Nebula: %s", resp.Status)
+		return ErrNebulaDownload
 	}
 
 	_, err = io.Copy(out, resp.Body)

--- a/nebula_darwin.go
+++ b/nebula_darwin.go
@@ -2,7 +2,6 @@ package nerf
 
 import (
 	"bufio"
-	fmt "fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -75,7 +74,7 @@ func nebulaGetNameServers() error {
 	}
 
 	if len(nameServers) == 0 {
-		return fmt.Errorf("failed retrieving current name servers")
+		return ErrRetrievingCurrentNameServers
 	}
 
 	Cfg.Logger.Debug("saving current name servers", zap.Strings("NameServers", nameServers))
@@ -101,7 +100,7 @@ func NebulaSetNameServers(e *Endpoint, NameServers []string, save bool) error {
 	)
 	lines, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed 'networksetup listallnetworkservices'")
+		return ErrListNetworkDevices
 	}
 
 	for _, service := range strings.Split(string(lines), "\n") {

--- a/nebula_linux.go
+++ b/nebula_linux.go
@@ -1,7 +1,6 @@
 package nerf
 
 import (
-	"fmt"
 	"net"
 	"os/exec"
 	"path"
@@ -36,7 +35,7 @@ func nebulaGetNameServers() error {
 	)
 	lines, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed 'nmcli device show'")
+		return ErrListNetworkDevices
 	}
 
 	for _, param := range strings.Split(string(lines), "\n") {
@@ -51,7 +50,7 @@ func nebulaGetNameServers() error {
 	}
 
 	if len(nameServers) == 0 {
-		return fmt.Errorf("failed retrieving current name servers")
+		return ErrRetrievingCurrentNameServers
 	}
 
 	Cfg.Logger.Debug("saving current name servers", zap.Strings("NameServers", nameServers))

--- a/nerf_server.go
+++ b/nerf_server.go
@@ -2,7 +2,6 @@ package nerf
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -44,7 +43,7 @@ type Teams struct {
 // Ping get timestamp in milliseconds
 func (s *Server) Ping(ctx context.Context, in *PingRequest) (*PingResponse, error) {
 	if *in.Login == "" {
-		return nil, fmt.Errorf("failed gRPC ping request")
+		return nil, ErrGrpcPing
 	}
 
 	ServerCfg.Logger.Debug("got ping request", zap.String("Login", *in.Login))
@@ -120,7 +119,7 @@ func (s *Server) Disconnect(ctx context.Context, in *Notify) (*google_protobuf.E
 	var err error
 
 	if *in.Login == "" {
-		err = fmt.Errorf("failed gRPC disconnect request")
+		err = ErrGrpcDisconnect
 	}
 
 	ServerCfg.Logger.Debug("disconnect", zap.String("Login", *in.Login))
@@ -131,7 +130,7 @@ func (s *Server) Disconnect(ctx context.Context, in *Notify) (*google_protobuf.E
 // Connect - connects to the server which generates config.yml for Nebula
 func (s *Server) Connect(ctx context.Context, in *Request) (*Response, error) {
 	if *in.Login == "" {
-		return nil, fmt.Errorf("failed gRPC certificate request")
+		return nil, ErrGrpcConnect
 	}
 
 	ServerCfg.Logger.Debug("connect", zap.String("Login", *in.Login))
@@ -143,13 +142,13 @@ func (s *Server) Connect(ctx context.Context, in *Request) (*Response, error) {
 	client := github.NewClient(oclient)
 	user, _, err := client.Users.Get(context.Background(), "")
 	if err != nil {
-		return nil, fmt.Errorf("failed validate login %s(%s): %s\n", user, *in.Login, err)
+		return nil, ErrValidateLogin
 	}
 
 	userTeams := teamsByUser(*user.Login)
 	if len(userTeams) == 0 {
 		ServerCfg.Logger.Debug("teams not found", zap.String("Login", *user.Login))
-		return nil, fmt.Errorf("No teams founds")
+		return nil, ErrNoTeamsFound
 	}
 
 	ServerCfg.Login = *user.Login


### PR DESCRIPTION
Loop at `nerf-api` until no errors from the Nerf server. 

Related: https://github.com/ton31337/nerf/issues/50