### PR TITLE
GUI: Avoid crash when stopping not started ticker

### DIFF
--- a/cmd/nerf/main.go
+++ b/cmd/nerf/main.go
@@ -88,6 +88,10 @@ func guiConnected() {
 	go func() {
 		for {
 			<-connectionTicker.C
+			if !nerf.Cfg.Connected {
+				connectionTicker.Stop()
+				return
+			}
 			connectionDuration := int(time.Since(connectionTime).Seconds())
 			mStatus.SetTitle("Status: Connected (" + fmt.Sprintf("%02d:%02d:%02d", connectionDuration/3600, (connectionDuration%3600)/60, connectionDuration%60) + ")")
 		}
@@ -101,7 +105,6 @@ func guiDisconnected() {
 	mConnect.Show()
 	mConnect.Enable()
 	mDisconnect.Hide()
-	connectionTicker.Stop()
 }
 
 func guiConnecting() {


### PR DESCRIPTION
This happens when backend not responds and gui changing status from `connecting` to `not connected`, ticker not started in this case and executes `ticker.stop` which is not started.

The ticker by itself does not provide the ability to know if it is started.